### PR TITLE
APIPA IP address added to the victim exclusion list

### DIFF
--- a/slimjim
+++ b/slimjim
@@ -118,7 +118,7 @@ while read null MAC1 null MAC2 null null null IP1 null IP2 null ; do
 			victim_ip=$IP2
 		fi
 		case "${victim_ip}" in
-			0.0.0.0|239.*.*.*|240.*.*.*|255.*.*.*)
+			0.0.0.0|169.254.0.0|239.*.*.*|240.*.*.*|255.*.*.*)
 				victim_ip=''
 				;;
 		esac

--- a/slimjim
+++ b/slimjim
@@ -118,7 +118,7 @@ while read null MAC1 null MAC2 null null null IP1 null IP2 null ; do
 			victim_ip=$IP2
 		fi
 		case "${victim_ip}" in
-			0.0.0.0|169.254.0.0|239.*.*.*|240.*.*.*|255.*.*.*)
+			0.0.0.0|169.254.*.*|239.*.*.*|240.*.*.*|255.*.*.*)
 				victim_ip=''
 				;;
 		esac


### PR DESCRIPTION
APIPA assigns a class B IP address from 169.254.0.0 to 169.254.255.255 to the client when a DHCP server is either permanently or temporarily unavailable or when the Victim is trying to reach the DHCP server and is already configured with an APIPA IP.
The slimjim script identifies the APIPA IP as the victim IP and translates all traffic with the APIPA source IP.
